### PR TITLE
Update for py3.9, replace getchildren() which was deprecated in 3.9 with list()

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -151,7 +151,7 @@ class OutlineProcessor(Treeprocessor):
         pattern = re.compile('^h(\d)')
         wrapper_cls = self.wrapper_cls
 
-        for child in node.getchildren():
+        for child in list(node):
             match = pattern.match(child.tag.lower())
 
             if match:


### PR DESCRIPTION
Anand helped me with this :-) so, we could do this as a workaround instead of replacing mdx_outline...